### PR TITLE
Fixed Resources.NotFoundException on older devices.

### DIFF
--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
@@ -1,7 +1,6 @@
 package uk.co.chrisjenx.calligraphy;
 
 import android.content.Context;
-import android.content.res.Resources;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -99,12 +98,7 @@ class CalligraphyFactory implements LayoutInflater.Factory {
             // Since we're not using namespace it's a little bit tricky
 
             // Try view xml attributes
-            String textViewFont = null;
-            try {
-                textViewFont = CalligraphyUtils.pullFontPath(context, attrs, mAttributeId);
-            } catch (Resources.NotFoundException e) {
-                // invalid attribute ID
-            }
+            String textViewFont = CalligraphyUtils.pullFontPath(context, attrs, mAttributeId);
 
             // Try view style attributes
             if (TextUtils.isEmpty(textViewFont)) {

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
@@ -45,8 +45,14 @@ public final class CalligraphyUtils {
         applyFontToTextView(context, textView, config);
     }
 
-    static final String pullFontPath(Context context, AttributeSet attrs, int attributeId) throws Resources.NotFoundException {
-        final String attributeName = context.getResources().getResourceEntryName(attributeId);
+    static final String pullFontPath(Context context, AttributeSet attrs, int attributeId) {
+        String attributeName;
+        try {
+            attributeName = context.getResources().getResourceEntryName(attributeId);
+        } catch (Resources.NotFoundException e) {
+            // invalid attribute ID
+            return null;
+        }
         final int stringResourceId = attrs.getAttributeResourceValue(null, attributeName, -1);
         return stringResourceId > 0
                 ? context.getString(stringResourceId)


### PR DESCRIPTION
Catch the exception and keep trying other approaches to get the font (style, theme attributes).

Fixes #30.
