### PR TITLE
null typeface => IllegalArgumentException

### DIFF
--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyTypefaceSpan.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyTypefaceSpan.java
@@ -9,6 +9,10 @@ public class CalligraphyTypefaceSpan extends MetricAffectingSpan {
     private final Typeface typeface;
 
     public CalligraphyTypefaceSpan(final Typeface typeface) {
+        if (typeface == null) {
+            throw new IllegalArgumentException("typeface is null");
+        }
+        
         this.typeface = typeface;
     }
 


### PR DESCRIPTION
Fail with a correct error message, if the supplied typeface is `null`.