### PR TITLE
Remove OnGlobalLayoutListener after use

### DIFF
--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
@@ -180,12 +180,16 @@ class CalligraphyFactory {
             parent.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
                 @Override
                 public void onGlobalLayout() {
-                    // No children, do nuffink!
-                    if (parent.getChildCount() <= 0) return;
-                    // Process children, defer draw as it has set the typeface.
-                    for (int i = 0; i < parent.getChildCount(); i++) {
-                        onViewCreated(parent.getChildAt(i), context, null);
+                    int childCount = parent.getChildCount();
+                    if (childCount != 0) {
+                        // Process children, defer draw as it has set the typeface.
+                        for (int i = 0; i < childCount; i++) {
+                            onViewCreated(parent.getChildAt(i), context, null);
+                        }
                     }
+
+                    // Our dark deed is done
+                    parent.getViewTreeObserver().removeGlobalOnLayoutListener(this);
                 }
             });
         }


### PR DESCRIPTION
Whether or not there are any children, we need to make sure that we
don't keep listening for global layout changes; it's unnecessary work
plus it also sticks around until the Activity is killed.

Addresses #102