### PR TITLE
Fix configuration example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Unfortunately `Activity#onCreate(Bundle)` is called _after_ `Activity#attachBase
 the config needs to be defined before that.
 
 ```java
-protected void onCreate() {
+@Override
+public void onCreate() {
     super.onCreate();
     CalligraphyConfig.initDefault(new CalligraphyConfig.Builder()
                             .setDefaultFontPath("fonts/Roboto-RobotoRegular.ttf")


### PR DESCRIPTION
Just a minor correction to an access modifier in an example along with an `@Override` annotation for consistency with the following example.