### PR TITLE
Fix exception with support library v22.1.0

### DIFF
--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -29,8 +29,8 @@ android {
 
 dependencies {
     compile project(':calligraphy')
-    compile 'com.android.support:support-v4:21.0.3'
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:support-v4:22.1.0'
+    compile 'com.android.support:appcompat-v7:22.1.0'
 
     compile 'com.jakewharton:butterknife:5.1.2'
 }

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyContextWrapper.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyContextWrapper.java
@@ -109,6 +109,7 @@ public class CalligraphyContextWrapper extends ContextWrapper {
         if (LAYOUT_INFLATER_SERVICE.equals(name)) {
             if (mInflater == null) {
                 mInflater = new CalligraphyLayoutInflater(LayoutInflater.from(getBaseContext()), this, mAttributeId);
+                mInflater.setUpLayoutFactories();
             }
             return mInflater;
         }

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyLayoutInflater.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyLayoutInflater.java
@@ -68,8 +68,9 @@ class CalligraphyLayoutInflater extends LayoutInflater implements CalligraphyAct
         // If we are HC+ we get and set Factory2 otherwise we just wrap Factory1
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             if (getFactory2() != null && !(getFactory2() instanceof WrapperFactory2)) {
-                // Sets both Factory/Factory2
+                // Sets Factory2 only
                 setFactory2(getFactory2());
+                return;
             }
         }
         // We can do this as setFactory2 is used for both methods.

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyLayoutInflater.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyLayoutInflater.java
@@ -34,14 +34,12 @@ class CalligraphyLayoutInflater extends LayoutInflater implements CalligraphyAct
         super(context);
         mAttributeId = attributeId;
         mCalligraphyFactory = new CalligraphyFactory(attributeId);
-        setUpLayoutFactories();
     }
 
     protected CalligraphyLayoutInflater(LayoutInflater original, Context newContext, int attributeId) {
         super(original, newContext);
         mAttributeId = attributeId;
         mCalligraphyFactory = new CalligraphyFactory(attributeId);
-        setUpLayoutFactories();
     }
 
     @Override
@@ -64,7 +62,7 @@ class CalligraphyLayoutInflater extends LayoutInflater implements CalligraphyAct
      * We don't want to unnecessary create/set our factories if there are none there. We try to be
      * as lazy as possible.
      */
-    private void setUpLayoutFactories() {
+    void setUpLayoutFactories() {
         // If we are HC+ we get and set Factory2 otherwise we just wrap Factory1
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             if (getFactory2() != null && !(getFactory2() instanceof WrapperFactory2)) {


### PR DESCRIPTION
Fix #155 

By my research, there are two points to be fixed.

### First point

When I updated support library and run sample, I saw `java.lang.IllegalStateException: A factory has already been set on this LayoutInflater`.
This exception was caused by that `CalligraphyLayoutInflater#setUpLayoutFactories` calls `setFactory2` and `setFactory`.

### Second point

When I fixed the first point, I saw same exception, which was raised by that  'LayoutInflaterCompat.setFactory' was called in Fragment.java. I think Fragment supposes that `mActivity.getLayoutInflater().cloneInContext(mActivity);` returns LayoutInflater object which is never called `setFactory/setFactory2`. Therefore I have fixed so that setUpLayoutFactories is not called in constructor.


I'm not sure that this PR fixes this problem for all devices / OS versions and I have not tested with many situations. Does anyone have any better idea?