### PR TITLE
Fixes Calligraphy for AppCompat 22.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 #Changelog
 
+#2.1.0 (27/04/2015)
+- Fixed #155, We now clone correctly.
+- Added Styles for Custom Views. (`builder.addCustomStyle(ToggleButton.class, android.R.attr.buttonStyleToggle)`)
+
 #2.0.2 (05/01/2015)
 - Fixed `CalligraphyConfig.Builder` missing return statements.
 - Fixed `createView()` getting the wrong parent context, Fixed: #135, #120

--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -3,18 +3,18 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.1.3'
     }
 }
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         minSdkVersion 7
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode project.ext.versionCodeInt
         versionName version
     }
@@ -29,8 +29,8 @@ android {
 
 dependencies {
     compile project(':calligraphy')
-    compile 'com.android.support:support-v4:21.0.3'
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:support-v4:22.1.1'
+    compile 'com.android.support:appcompat-v7:22.1.1'
 
     compile 'com.jakewharton:butterknife:5.1.2'
 }

--- a/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/MainActivity.java
+++ b/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/MainActivity.java
@@ -5,10 +5,11 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 
 import uk.co.chrisjenx.calligraphy.CalligraphyContextWrapper;
 
-public class MainActivity extends ActionBarActivity {
+public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/PlaceholderFragment.java
+++ b/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/PlaceholderFragment.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewStub;
 import android.widget.Toast;
+
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 

--- a/CalligraphySample/src/main/res/layout/fragment_main.xml
+++ b/CalligraphySample/src/main/res/layout/fragment_main.xml
@@ -93,6 +93,7 @@
             android:text="@string/checkbox_custom"/>
 
         <EditText
+            android:id="@+id/edit_text"
             fontPath="fonts/Roboto-Bold.ttf"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Are you fed up of Custom Views to set fonts? Or traversing the ViewTree to find 
 
 ### Dependency
 
-Include the dependency [Download (.aar)](http://search.maven.org/remotecontent?filepath=uk/co/chrisjenx/calligraphy/2.0.2/calligraphy-2.0.2.aar) :
+Include the dependency [Download (.aar)](http://search.maven.org/remotecontent?filepath=uk/co/chrisjenx/calligraphy/2.1.0/calligraphy-2.1.0.aar) :
 
 ```groovy
 dependencies {
-    compile 'uk.co.chrisjenx:calligraphy:2.0.2'
+    compile 'uk.co.chrisjenx:calligraphy:2.1.0'
 }
 ```
 ### Add Fonts

--- a/calligraphy/build.gradle
+++ b/calligraphy/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.1.3'
     }
 }
 apply plugin: 'com.android.library'
@@ -13,12 +13,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         minSdkVersion 7
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode project.ext.versionCodeInt
         versionName version
     }
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    provided 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:appcompat-v7:22.1.1'
 }
 
 apply from: '../gradle/deploy.gradle'

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyContextWrapper.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyContextWrapper.java
@@ -108,7 +108,7 @@ public class CalligraphyContextWrapper extends ContextWrapper {
     public Object getSystemService(String name) {
         if (LAYOUT_INFLATER_SERVICE.equals(name)) {
             if (mInflater == null) {
-                mInflater = new CalligraphyLayoutInflater(LayoutInflater.from(getBaseContext()), this, mAttributeId);
+                mInflater = new CalligraphyLayoutInflater(LayoutInflater.from(getBaseContext()), this, mAttributeId, true);
             }
             return mInflater;
         }

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyContextWrapper.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyContextWrapper.java
@@ -108,7 +108,7 @@ public class CalligraphyContextWrapper extends ContextWrapper {
     public Object getSystemService(String name) {
         if (LAYOUT_INFLATER_SERVICE.equals(name)) {
             if (mInflater == null) {
-                mInflater = new CalligraphyLayoutInflater(LayoutInflater.from(getBaseContext()), this, mAttributeId, true);
+                mInflater = new CalligraphyLayoutInflater(LayoutInflater.from(getBaseContext()), this, mAttributeId, false);
             }
             return mInflater;
         }

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyLayoutInflater.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyLayoutInflater.java
@@ -3,7 +3,6 @@ package uk.co.chrisjenx.calligraphy;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
-import android.support.v4.view.LayoutInflaterFactory;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -259,7 +258,7 @@ class CalligraphyLayoutInflater extends LayoutInflater implements CalligraphyAct
      * Factory 2 is the second port of call for LayoutInflation
      */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-    private static class WrapperFactory2 implements Factory2, LayoutInflaterFactory {
+    private static class WrapperFactory2 implements Factory2 {
         protected final Factory2 mFactory2;
         protected final CalligraphyFactory mCalligraphyFactory;
 

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyLayoutInflater.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyLayoutInflater.java
@@ -3,6 +3,8 @@ package uk.co.chrisjenx.calligraphy;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
+import android.support.v4.view.LayoutInflaterCompat;
+import android.support.v4.view.LayoutInflaterFactory;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;


### PR DESCRIPTION
Due to the underlying bug in the platform the new AppCompat tools forces setting `Factory2` where it would not be set if creating a `FactoryMerger`.
That doesn't really affect us, but this did mean they started setting factories on cloned `LayoutInflaters` where the bug does exist, which they didn't do previously on older Fragment versions.

This fixes cloning so we set our wrapper gracefully and only the first time.

Fixes: #155, #158, #161 
