### PR TITLE
Add ability to resolve attr for view styles

### DIFF
--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
@@ -167,7 +167,26 @@ public final class CalligraphyUtils {
         final int stringResourceId = attrs.getAttributeResourceValue(null, attributeName, -1);
         return stringResourceId > 0
                 ? context.getString(stringResourceId)
-                : attrs.getAttributeValue(null, attributeName);
+                : pullFontPathFromAttribute(context, attrs.getAttributeValue(null, attributeName));
+    }
+
+    /**
+     * Tries to convert from an attribute to a String
+     */
+    static String pullFontPathFromAttribute(Context context, String attribute) {
+        String value = null;
+        if (attribute != null && attribute.startsWith("?bread")) {
+            try {
+                int identifier = context.getResources().getIdentifier(attribute.substring(1),
+                        "attr",
+                        context.getPackageName());
+                TypedValue attr = new TypedValue();
+                context.getTheme().resolveAttribute(identifier, attr, true);
+                value = attr.coerceToString().toString();
+            } catch (NullPointerException ignore) { /* Handle a missing attr or invalid value */ }
+        }
+        if (value == null) value = attribute; // Allow this to work as it always has
+        return value;
     }
 
     /**

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
@@ -175,7 +175,7 @@ public final class CalligraphyUtils {
      */
     static String pullFontPathFromAttribute(Context context, String attribute) {
         String value = null;
-        if (attribute != null && attribute.startsWith("?bread")) {
+        if (attribute != null && attribute.startsWith("?")) {
             try {
                 int identifier = context.getResources().getIdentifier(attribute.substring(1),
                         "attr",


### PR DESCRIPTION
Currently, setting the font to an attr value causes it to look for a font named - for example - "?attr/myThemeSpecificFont" instead of resolving it to the theme's value. This adds support for setting fontPath to an attr value per view. 
