### PR TITLE
Add ignoreClass to Builder

### DIFF
--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -32,5 +32,7 @@ dependencies {
     compile 'com.android.support:support-v4:22.1.1'
     compile 'com.android.support:appcompat-v7:22.1.1'
 
+    compile 'com.malinskiy:materialicons:1.0.2'
+
     compile 'com.jakewharton:butterknife:5.1.2'
 }

--- a/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/CalligraphyApplication.java
+++ b/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/CalligraphyApplication.java
@@ -2,6 +2,8 @@ package uk.co.chrisjenx.calligraphy.sample;
 
 import android.app.Application;
 
+import com.malinskiy.materialicons.widget.IconTextView;
+
 import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
 
 /**
@@ -17,6 +19,7 @@ public class CalligraphyApplication extends Application {
                         .setDefaultFontPath("fonts/Roboto-ThinItalic.ttf")
                         .setFontAttrId(R.attr.fontPath)
                         .addCustomStyle(TextField.class, R.attr.textFieldStyle)
+                        .ignoreClass(IconTextView.class)
                         .build()
         );
     }

--- a/CalligraphySample/src/main/res/layout/fragment_main.xml
+++ b/CalligraphySample/src/main/res/layout/fragment_main.xml
@@ -106,6 +106,11 @@
             android:layout_height="wrap_content"
             android:text="@string/custom_view_style_text"/>
 
+        <com.malinskiy.materialicons.widget.IconTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/defined_ingore_class"/>
+
         <Button
             android:id="@+id/button_default"
             android:layout_width="wrap_content"

--- a/CalligraphySample/src/main/res/values/strings.xml
+++ b/CalligraphySample/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="defined_in_appears">\nThis has the font path defined in the Views TextAppearance as Oswald.\n</string>
     <string name="defined_in_appears_caps">\nThis has the font path defined in the Views TextAppearance as Oswald. textAllCaps is applied.\n</string>
     <string name="defined_custom_view">\nThis is a custom TextView with Oswald font.\n</string>
+    <string name="defined_ingore_class">Ignore class works for iconify libraries for {zmdi-android} {zmdi-favorite}</string>
     <string name="defined_view_stub">\nThis is a TextView inflated from a ViewStub.\n</string>
     <string name="defined_view_stub_font_path">\nThis is a TextView inflated from a ViewStub w/ fontPath declared.\n</string>
 

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
@@ -13,7 +13,9 @@ import android.widget.ToggleButton;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Created by chris on 20/12/2013
@@ -86,6 +88,10 @@ public class CalligraphyConfig {
      * Class Styles. Build from DEFAULT_STYLES and the builder.
      */
     private final Map<Class<? extends TextView>, Integer> mClassStyleAttributeMap;
+    /**
+     * Classes that will not be injected
+     */
+    private final Set<Class<?>> mIgnoredClassSet;
 
     protected CalligraphyConfig(Builder builder) {
         mIsFontSet = builder.isFontSet;
@@ -96,6 +102,7 @@ public class CalligraphyConfig {
         final Map<Class<? extends TextView>, Integer> tempMap = new HashMap<>(DEFAULT_STYLES);
         tempMap.putAll(builder.mStyleClassMap);
         mClassStyleAttributeMap = Collections.unmodifiableMap(tempMap);
+        mIgnoredClassSet = Collections.unmodifiableSet(new HashSet<>(builder.mIgnoredClassSet));
     }
 
     /**
@@ -131,6 +138,15 @@ public class CalligraphyConfig {
         return mAttrId;
     }
 
+    /**
+     *
+     * @param viewClass class to be ignored by Calligraphy
+     * @return true if class should not be injected, false otherwise
+     */
+    public boolean isIgnoredClass(Class<?> viewClass) {
+        return mIgnoredClassSet.contains(viewClass);
+    }
+
     public static class Builder {
         /**
          * Default AttrID if not set.
@@ -160,7 +176,10 @@ public class CalligraphyConfig {
          * Additional Class Styles. Can be empty.
          */
         private Map<Class<? extends TextView>, Integer> mStyleClassMap = new HashMap<>();
-
+        /**
+         * Ignored classes. Can be empty.
+         */
+        private Set<Class<?>> mIgnoredClassSet = new HashSet<>();
         /**
          * This defaults to R.attr.fontPath. So only override if you want to use your own attrId.
          *
@@ -254,6 +273,12 @@ public class CalligraphyConfig {
         public Builder addCustomStyle(final Class<? extends TextView> styleClass, final int styleResourceAttribute) {
             if (styleClass == null || styleResourceAttribute == 0) return this;
             mStyleClassMap.put(styleClass, styleResourceAttribute);
+            return this;
+        }
+
+        public Builder ignoreClass(final Class<?> clazz) {
+            if(clazz == null) return this;
+            mIgnoredClassSet.add(clazz);
             return this;
         }
 

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
@@ -114,7 +114,7 @@ class CalligraphyFactory {
     }
 
     void onViewCreatedInternal(View view, final Context context, AttributeSet attrs) {
-        if (view instanceof TextView) {
+        if (!CalligraphyConfig.get().isIgnoredClass(view.getClass()) && view instanceof TextView) {
             // Fast path the setting of TextView's font, means if we do some delayed setting of font,
             // which has already been set by use we skip this TextView (mainly for inflating custom,
             // TextView's inside the Toolbar/ActionBar).


### PR DESCRIPTION
Iconify projects like (https://github.com/Malinskiy/android-material-icons)[android-material-icons] and (https://github.com/JoanZapata/android-iconify)[android-iconify] have custom TextView classes that should be able to load custom fonts on their own without Calligraphy interfering