### PR TITLE
Add support of CalligraphyFactoryPlugin

### DIFF
--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 apply plugin: 'com.android.application'

--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 apply plugin: 'com.android.application'

--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-rc1'
+        classpath 'com.android.tools.build:gradle:2.0.0-rc2'
     }
 }
 apply plugin: 'com.android.application'

--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -3,24 +3,24 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 }
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    compileSdkVersion 25
+    buildToolsVersion '23.0.3'
 
     defaultConfig {
         minSdkVersion 7
-        targetSdkVersion 22
+        //noinspection OldTargetApi
+        targetSdkVersion 23
         versionCode project.ext.versionCodeInt
         versionName version
     }
     buildTypes {
         release {
-
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
@@ -29,8 +29,8 @@ android {
 
 dependencies {
     compile project(':calligraphy')
-    compile 'com.android.support:support-v4:23.1.1'
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:support-v4:25.3.1'
+    compile 'com.android.support:appcompat-v7:25.3.1'
 
     compile 'com.jakewharton:butterknife:5.1.2'
 }

--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.2.0'
     }
 }
 apply plugin: 'com.android.application'

--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-rc2'
+        classpath 'com.android.tools.build:gradle:2.0.0-rc3'
     }
 }
 apply plugin: 'com.android.application'

--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-rc3'
+        classpath 'com.android.tools.build:gradle:2.0.0'
     }
 }
 apply plugin: 'com.android.application'

--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -9,8 +9,8 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion '23.0.2'
 
     defaultConfig {
         minSdkVersion 7
@@ -29,8 +29,8 @@ android {
 
 dependencies {
     compile project(':calligraphy')
-    compile 'com.android.support:support-v4:22.1.1'
-    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.android.support:support-v4:23.1.1'
+    compile 'com.android.support:appcompat-v7:23.1.1'
 
     compile 'com.jakewharton:butterknife:5.1.2'
 }

--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
     }
 }
 apply plugin: 'com.android.application'

--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
+        classpath 'com.android.tools.build:gradle:2.0.0-rc1'
     }
 }
 apply plugin: 'com.android.application'

--- a/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/CalligraphyApplication.java
+++ b/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/CalligraphyApplication.java
@@ -17,6 +17,7 @@ public class CalligraphyApplication extends Application {
                         .setDefaultFontPath("fonts/Roboto-ThinItalic.ttf")
                         .setFontAttrId(R.attr.fontPath)
                         .addCustomStyle(TextField.class, R.attr.textFieldStyle)
+                        .addFactoryPlugin(new ThirdPartyCustomViewCalligraphyFactoryPlugin(R.attr.fontPath))
                         .build()
         );
     }

--- a/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/ThirdPartyCustomView.java
+++ b/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/ThirdPartyCustomView.java
@@ -1,0 +1,43 @@
+package uk.co.chrisjenx.calligraphy.sample;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Typeface;
+import android.util.AttributeSet;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+/**
+ * Sample of a third party custom view NOT extending TextView class.
+ * In the sample application, the customization of this third party view is done using a
+ * registered CalligraphyFactoryPlugin.
+ */
+public class ThirdPartyCustomView extends LinearLayout {
+
+    TextView innerTextView;
+
+    public ThirdPartyCustomView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        createInnerTextView(context, attrs);
+    }
+
+    private void createInnerTextView(Context context, AttributeSet attrs) {
+        innerTextView = new TextView(context);
+
+        int[] set = {
+                android.R.attr.text
+        };
+        TypedArray a = context.obtainStyledAttributes(attrs, set);
+
+        innerTextView.setText("Third party internal TextView created programmatically: " + a.getText(0));
+
+        a.recycle();
+
+        addView(this.innerTextView);
+    }
+
+    public void setTypeface(Typeface tf) {
+        innerTextView.setTypeface(tf);
+    }
+
+}

--- a/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/ThirdPartyCustomViewCalligraphyFactoryPlugin.java
+++ b/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/ThirdPartyCustomViewCalligraphyFactoryPlugin.java
@@ -1,0 +1,37 @@
+package uk.co.chrisjenx.calligraphy.sample;
+
+import android.content.Context;
+import android.graphics.Typeface;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.view.View;
+
+import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
+import uk.co.chrisjenx.calligraphy.CalligraphyFactoryPlugin;
+import uk.co.chrisjenx.calligraphy.CalligraphyUtils;
+import uk.co.chrisjenx.calligraphy.TypefaceUtils;
+
+/**
+ * Sample CalligraphyFactoryPlugin: apply font for ThirdPartyCustomView objects.
+ */
+public class ThirdPartyCustomViewCalligraphyFactoryPlugin implements CalligraphyFactoryPlugin {
+    private final int attributeId;
+
+    public ThirdPartyCustomViewCalligraphyFactoryPlugin(int attributeId) {
+        this.attributeId = attributeId;
+    }
+
+    @Override
+    public void onViewCreated(View view, Context context, AttributeSet attrs) {
+        if (view instanceof ThirdPartyCustomView) {
+            ThirdPartyCustomView thirdPartyCustomView = (ThirdPartyCustomView) view;
+
+            String fontPath = CalligraphyUtils.pullFontPathFromAttributesHierarchyWithDefault(context, attrs, attributeId, CalligraphyConfig.get());
+
+            if (!TextUtils.isEmpty(fontPath)) {
+                Typeface typeface = TypefaceUtils.load(context.getAssets(), fontPath);
+                thirdPartyCustomView.setTypeface(typeface);
+            }
+        }
+    }
+}

--- a/CalligraphySample/src/main/res/layout/fragment_main.xml
+++ b/CalligraphySample/src/main/res/layout/fragment_main.xml
@@ -106,6 +106,20 @@
             android:layout_height="wrap_content"
             android:text="@string/custom_view_style_text"/>
 
+
+        <uk.co.chrisjenx.calligraphy.sample.ThirdPartyCustomView
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/default_theme"/>
+
+        <uk.co.chrisjenx.calligraphy.sample.ThirdPartyCustomView
+            fontPath="fonts/Roboto-Bold.ttf"
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/defined_fontpath_view"/>
+
         <Button
             android:id="@+id/button_default"
             android:layout_width="wrap_content"

--- a/build.gradle
+++ b/build.gradle
@@ -10,5 +10,5 @@ allprojects {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.2'
+    gradleVersion = '3.5'
 }

--- a/calligraphy/build.gradle
+++ b/calligraphy/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.2.0'
     }
 }
 apply plugin: 'com.android.library'

--- a/calligraphy/build.gradle
+++ b/calligraphy/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 apply plugin: 'com.android.library'

--- a/calligraphy/build.gradle
+++ b/calligraphy/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 apply plugin: 'com.android.library'

--- a/calligraphy/build.gradle
+++ b/calligraphy/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-rc1'
+        classpath 'com.android.tools.build:gradle:2.0.0-rc2'
     }
 }
 apply plugin: 'com.android.library'

--- a/calligraphy/build.gradle
+++ b/calligraphy/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-rc3'
+        classpath 'com.android.tools.build:gradle:2.0.0'
     }
 }
 apply plugin: 'com.android.library'

--- a/calligraphy/build.gradle
+++ b/calligraphy/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 }
 apply plugin: 'com.android.library'
@@ -13,12 +13,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    compileSdkVersion 25
+    buildToolsVersion '23.0.3'
 
     defaultConfig {
         minSdkVersion 7
-        targetSdkVersion 22
+        //noinspection OldTargetApi
+        targetSdkVersion 23
         versionCode project.ext.versionCodeInt
         versionName version
     }
@@ -31,7 +32,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:25.3.1'
 }
 
 apply from: '../gradle/deploy.gradle'

--- a/calligraphy/build.gradle
+++ b/calligraphy/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
+        classpath 'com.android.tools.build:gradle:2.0.0-rc1'
     }
 }
 apply plugin: 'com.android.library'

--- a/calligraphy/build.gradle
+++ b/calligraphy/build.gradle
@@ -13,8 +13,8 @@ repositories {
 }
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion '23.0.2'
 
     defaultConfig {
         minSdkVersion 7
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.android.support:appcompat-v7:23.1.1'
 }
 
 apply from: '../gradle/deploy.gradle'

--- a/calligraphy/build.gradle
+++ b/calligraphy/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-rc2'
+        classpath 'com.android.tools.build:gradle:2.0.0-rc3'
     }
 }
 apply plugin: 'com.android.library'

--- a/calligraphy/build.gradle
+++ b/calligraphy/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
     }
 }
 apply plugin: 'com.android.library'

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
@@ -11,8 +11,11 @@ import android.widget.RadioButton;
 import android.widget.TextView;
 import android.widget.ToggleButton;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -86,6 +89,10 @@ public class CalligraphyConfig {
      * Class Styles. Build from DEFAULT_STYLES and the builder.
      */
     private final Map<Class<? extends TextView>, Integer> mClassStyleAttributeMap;
+    /**
+     * Calligraphy factory plugins to notify on view creation. Can be null.
+     */
+    private final List<CalligraphyFactoryPlugin> mfactoryPlugins;
 
     protected CalligraphyConfig(Builder builder) {
         mIsFontSet = builder.isFontSet;
@@ -96,6 +103,7 @@ public class CalligraphyConfig {
         final Map<Class<? extends TextView>, Integer> tempMap = new HashMap<>(DEFAULT_STYLES);
         tempMap.putAll(builder.mStyleClassMap);
         mClassStyleAttributeMap = Collections.unmodifiableMap(tempMap);
+        mfactoryPlugins = builder.factoryPlugins;
     }
 
     /**
@@ -131,6 +139,13 @@ public class CalligraphyConfig {
         return mAttrId;
     }
 
+    /**
+     * @return factory plugins to notify on view creation. Can be null.
+     */
+    List<CalligraphyFactoryPlugin> getFactoryPlugins() {
+        return mfactoryPlugins;
+    }
+
     public static class Builder {
         /**
          * Default AttrID if not set.
@@ -160,6 +175,10 @@ public class CalligraphyConfig {
          * Additional Class Styles. Can be empty.
          */
         private Map<Class<? extends TextView>, Integer> mStyleClassMap = new HashMap<>();
+        /**
+         * Custom CalligraphyFactory plugins. Can be null.
+         */
+        private List<CalligraphyFactoryPlugin> factoryPlugins;
 
         /**
          * This defaults to R.attr.fontPath. So only override if you want to use your own attrId.
@@ -257,9 +276,27 @@ public class CalligraphyConfig {
             return this;
         }
 
+        /**
+         * Register a new CalligraphyFactoryPlugin. CalligraphyFactory's plugins will be called
+         * after a view has been created. The plugin can process custom attributes.
+         *
+         * @param calligraphyFactoryPlugin        the new plugin to register
+         * @return this builder.
+         */
+        public Builder addFactoryPlugin(CalligraphyFactoryPlugin calligraphyFactoryPlugin) {
+            if (factoryPlugins == null) {
+                factoryPlugins = new ArrayList<>();
+            }
+
+            factoryPlugins.add(calligraphyFactoryPlugin);
+
+            return this;
+        }
+
         public CalligraphyConfig build() {
             this.isFontSet = !TextUtils.isEmpty(fontAssetPath);
             return new CalligraphyConfig(this);
         }
+
     }
 }

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
@@ -11,6 +11,8 @@ import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.widget.TextView;
 
+import java.util.Collection;
+
 class CalligraphyFactory {
 
     private static final String ACTION_BAR_TITLE = "action_bar_title";
@@ -109,6 +111,13 @@ class CalligraphyFactory {
         if (view != null && view.getTag(R.id.calligraphy_tag_id) != Boolean.TRUE) {
             onViewCreatedInternal(view, context, attrs);
             view.setTag(R.id.calligraphy_tag_id, Boolean.TRUE);
+
+            Collection<CalligraphyFactoryPlugin> factoryPlugins = CalligraphyConfig.get().getFactoryPlugins();
+            if (factoryPlugins != null) {
+                for (CalligraphyFactoryPlugin plugin : factoryPlugins) {
+                    plugin.onViewCreated(view, context, attrs);
+                }
+            }
         }
         return view;
     }
@@ -124,18 +133,7 @@ class CalligraphyFactory {
             // Try to get typeface attribute value
             // Since we're not using namespace it's a little bit tricky
 
-            // Try view xml attributes
-            String textViewFont = CalligraphyUtils.pullFontPathFromView(context, attrs, mAttributeId);
-
-            // Try view style attributes
-            if (TextUtils.isEmpty(textViewFont)) {
-                textViewFont = CalligraphyUtils.pullFontPathFromStyle(context, attrs, mAttributeId);
-            }
-
-            // Try View TextAppearance
-            if (TextUtils.isEmpty(textViewFont)) {
-                textViewFont = CalligraphyUtils.pullFontPathFromTextAppearance(context, attrs, mAttributeId);
-            }
+            String textViewFont = CalligraphyUtils.pullFontPathFromAttributesHierarchy(context, attrs, mAttributeId);
 
             // Try theme attributes
             if (TextUtils.isEmpty(textViewFont)) {
@@ -179,6 +177,5 @@ class CalligraphyFactory {
             });
         }
     }
-
 
 }

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactoryPlugin.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactoryPlugin.java
@@ -1,0 +1,15 @@
+package uk.co.chrisjenx.calligraphy;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+/**
+ * Define a plugin for CalligraphyFactory class. Plugins are called after a view has been inflated.
+ * The plugin can process custom attributes and apply them on the newly created view.
+ *
+ * Plugins are registered using {@code CalligraphyConfig.Builder.addFactoryPlugin()}
+ */
+public interface CalligraphyFactoryPlugin {
+    void onViewCreated(View view, Context context, AttributeSet attrs);
+}

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
@@ -144,6 +144,56 @@ public final class CalligraphyUtils {
         applyFontToTextView(context, textView, config, deferred);
     }
 
+
+    /**
+     * Tries to pull the fontPath in the right order:
+     *   1) view's attribute, 2) style, 3) textAppearance
+     *
+     * Fallback to the default font path defined in config if not found in the view's attribute
+     * hierarchy.
+     *
+     * @param context     Activity Context
+     * @param attrs       View Attributes
+     * @param attributeId if -1 returns null.
+     * @return null if attribute is not defined or added to View
+     */
+    public static String pullFontPathFromAttributesHierarchyWithDefault(Context context, AttributeSet attrs, int attributeId, CalligraphyConfig config) {
+
+        String fontPath = pullFontPathFromAttributesHierarchy(context, attrs, attributeId);
+
+        if (TextUtils.isEmpty(fontPath) && (config != null)) {
+            fontPath = config.getFontPath();
+        }
+
+        return fontPath;
+    }
+
+    /**
+     * Tries to pull the fontPath in the right order from attributes hierarchy:
+     *   1) view's attribute, 2) style, 3) textAppearance
+     *
+     * @param context     Activity Context
+     * @param attrs       View Attributes
+     * @param attributeId if -1 returns null.
+     * @return null if attribute is not defined or added to View
+     */
+    public static String pullFontPathFromAttributesHierarchy(Context context, AttributeSet attrs, int attributeId) {
+        // Try view xml attributes
+        String textViewFont = CalligraphyUtils.pullFontPathFromView(context, attrs, attributeId);
+
+        // Try view style attributes
+        if (TextUtils.isEmpty(textViewFont)) {
+            textViewFont = CalligraphyUtils.pullFontPathFromStyle(context, attrs, attributeId);
+        }
+
+        // Try View TextAppearance
+        if (TextUtils.isEmpty(textViewFont)) {
+            textViewFont = CalligraphyUtils.pullFontPathFromTextAppearance(context, attrs, attributeId);
+        }
+
+        return textViewFont;
+    }
+
     /**
      * Tries to pull the Custom Attribute directly from the TextView.
      *


### PR DESCRIPTION
Registered CalligraphyFactoryPlugins are called after a view has been inflated by the CalligraphyFactory.
The plugin can process custom attributes and apply them on the newly created view.

This gives a workaround for the following issues:
https://github.com/chrisjenx/Calligraphy/issues/171
https://github.com/chrisjenx/Calligraphy/issues/127
https://github.com/chrisjenx/Calligraphy/issues/103

Maybe this one also:
https://github.com/chrisjenx/Calligraphy/issues/82

![image](https://cloud.githubusercontent.com/assets/3072749/8657827/f34dacda-296d-11e5-8c82-3bdb390e9720.png)
