### PR TITLE
Fixed #160 - Crash when using labelFor attribute

### DIFF
--- a/CalligraphySample/src/main/res/layout/fragment_main.xml
+++ b/CalligraphySample/src/main/res/layout/fragment_main.xml
@@ -17,12 +17,14 @@
         tools:ignore="MissingPrefix">
 
         <TextView
+            android:id="@+id/basic_text_view"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/default_theme"/>
 
         <TextView
             fontPath="fonts/Roboto-Bold.ttf"
+            android:labelFor="@id/basic_text_view"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/defined_fontpath_view"/>

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
@@ -3,6 +3,7 @@ package uk.co.chrisjenx.calligraphy;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.res.Resources;
 import android.os.Build;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -86,8 +87,13 @@ class CalligraphyFactory {
      */
     protected static boolean matchesResourceIdName(View view, String matches) {
         if (view.getId() == View.NO_ID) return false;
-        final String resourceEntryName = view.getResources().getResourceEntryName(view.getId());
-        return resourceEntryName.equalsIgnoreCase(matches);
+        try {
+            final String resourceEntryName = view.getResources().getResourceEntryName(view.getId());
+            return resourceEntryName.equalsIgnoreCase(matches);
+        } catch (Resources.NotFoundException ex) {
+            // If the view is not found, return false, same as if we were not given an id
+            return false;
+        }
     }
 
     private final int mAttributeId;


### PR DESCRIPTION
Having a labelFor attribute was causing crashes in the CalligraphyFactory due to an uncaught ResourceNotFound exception. We should be catching this exception and treating it the same as if the view had NO_ID.