### PR TITLE
Added ability to set typefaces for custom views with setTypeface method

### DIFF
--- a/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/CalligraphyApplication.java
+++ b/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/CalligraphyApplication.java
@@ -16,6 +16,7 @@ public class CalligraphyApplication extends Application {
         CalligraphyConfig.initDefault(new CalligraphyConfig.Builder()
                         .setDefaultFontPath("fonts/Roboto-ThinItalic.ttf")
                         .setFontAttrId(R.attr.fontPath)
+                        .setCustomViewTypefaceSupport(true)
                         .addCustomStyle(TextField.class, R.attr.textFieldStyle)
                         .build()
         );

--- a/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/CalligraphyApplication.java
+++ b/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/CalligraphyApplication.java
@@ -16,7 +16,7 @@ public class CalligraphyApplication extends Application {
         CalligraphyConfig.initDefault(new CalligraphyConfig.Builder()
                         .setDefaultFontPath("fonts/Roboto-ThinItalic.ttf")
                         .setFontAttrId(R.attr.fontPath)
-                        .setCustomViewTypefaceSupport(true)
+                        .addCustomViewWithSetTypeface(CustomViewWithTypefaceSupport.class)
                         .addCustomStyle(TextField.class, R.attr.textFieldStyle)
                         .build()
         );

--- a/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/CustomViewWithTypefaceSupport.java
+++ b/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/CustomViewWithTypefaceSupport.java
@@ -1,0 +1,75 @@
+package uk.co.chrisjenx.calligraphy.sample;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.Typeface;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.View;
+
+/**
+ * @author Dmitriy Tarasov
+ */
+public class CustomViewWithTypefaceSupport extends View {
+
+    private Paint paint;
+    private Rect textBounds;
+    private int width;
+    private int height;
+
+    public CustomViewWithTypefaceSupport(Context context) {
+        super(context);
+        init();
+    }
+
+    public CustomViewWithTypefaceSupport(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public CustomViewWithTypefaceSupport(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public CustomViewWithTypefaceSupport(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init();
+    }
+
+    private void init() {
+        paint = new Paint();
+        paint.setTextSize(50);
+        textBounds = new Rect();
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        String text = "This is a custom view with setTypeface support";
+        Paint.FontMetrics fm = paint.getFontMetrics();
+        paint.getTextBounds(text, 0, text.length(), textBounds);
+
+        width = textBounds.left + textBounds.right + getPaddingLeft() + getPaddingRight();
+        height = (int) (Math.abs(fm.top) + fm.bottom);
+
+        canvas.drawText(text, 0, -fm.top + getPaddingTop(), paint);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        setMeasuredDimension(width, height);
+    }
+
+    /**
+     * Used by Calligraphy to change view's typeface
+     */
+    @SuppressWarnings("unused")
+    public void setTypeface(Typeface tf) {
+        paint.setTypeface(tf);
+        invalidate();
+    }
+}

--- a/CalligraphySample/src/main/res/layout/fragment_main.xml
+++ b/CalligraphySample/src/main/res/layout/fragment_main.xml
@@ -72,6 +72,11 @@
             android:layout_height="wrap_content"
             android:text="@string/defined_custom_view"/>
 
+        <uk.co.chrisjenx.calligraphy.sample.CustomViewWithTypefaceSupport
+            fontPath="fonts/Oswald-Stencbab.ttf"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
         <ViewStub
             android:id="@+id/stub"
             android:layout_width="wrap_content"

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.3.0-beta3'
+    classpath 'com.android.tools.build:gradle:1.3.0'
   }
 }
 

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
@@ -111,7 +111,10 @@ public class CalligraphyConfig {
      * Class Styles. Build from DEFAULT_STYLES and the builder.
      */
     private final Map<Class<? extends TextView>, Integer> mClassStyleAttributeMap;
-
+    /**
+     * Collection of custom non-{@code TextView}'s registered for applying typeface during inflation
+     * @see uk.co.chrisjenx.calligraphy.CalligraphyConfig.Builder#addCustomViewWithSetTypeface(Class)
+     */
     private final Set<Class<?>> hasTypefaceViews;
 
     protected CalligraphyConfig(Builder builder) {
@@ -301,7 +304,7 @@ public class CalligraphyConfig {
         }
 
         /**
-         * Registering custom view with setTypeface method to apply typeface during inflation via reflection
+         * Register custom non-{@code TextView}'s which implement {@code setTypeface} so they can have the Typeface applied during inflation.
          */
         public Builder addCustomViewWithSetTypeface(Class<?> clazz) {
             customViewTypefaceSupport = true;

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
@@ -2,6 +2,7 @@ package uk.co.chrisjenx.calligraphy;
 
 import android.os.Build;
 import android.text.TextUtils;
+import android.view.View;
 import android.widget.AutoCompleteTextView;
 import android.widget.Button;
 import android.widget.CheckBox;
@@ -13,7 +14,9 @@ import android.widget.ToggleButton;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Created by chris on 20/12/2013
@@ -109,6 +112,8 @@ public class CalligraphyConfig {
      */
     private final Map<Class<? extends TextView>, Integer> mClassStyleAttributeMap;
 
+    private final Set<Class<?>> hasTypefaceViews;
+
     protected CalligraphyConfig(Builder builder) {
         mIsFontSet = builder.isFontSet;
         mFontPath = builder.fontAssetPath;
@@ -119,6 +124,7 @@ public class CalligraphyConfig {
         final Map<Class<? extends TextView>, Integer> tempMap = new HashMap<>(DEFAULT_STYLES);
         tempMap.putAll(builder.mStyleClassMap);
         mClassStyleAttributeMap = Collections.unmodifiableMap(tempMap);
+        hasTypefaceViews = Collections.unmodifiableSet(builder.mHasTypefaceClasses);
     }
 
     /**
@@ -145,6 +151,10 @@ public class CalligraphyConfig {
 
     public boolean isCustomViewTypefaceSupport() {
         return mCustomViewTypefaceSupport;
+    }
+
+    public boolean isCustomViewHasTypeface(View view) {
+        return hasTypefaceViews.contains(view.getClass());
     }
 
     /* default */ Map<Class<? extends TextView>, Integer> getClassStyles() {
@@ -191,6 +201,8 @@ public class CalligraphyConfig {
          * Additional Class Styles. Can be empty.
          */
         private Map<Class<? extends TextView>, Integer> mStyleClassMap = new HashMap<>();
+
+        private Set<Class<?>> mHasTypefaceClasses = new HashSet<>();
 
         /**
          * This defaults to R.attr.fontPath. So only override if you want to use your own attrId.
@@ -266,11 +278,6 @@ public class CalligraphyConfig {
             return this;
         }
 
-        public Builder setCustomViewTypefaceSupport(boolean support) {
-            this.customViewTypefaceSupport = support;
-            return this;
-        }
-
         /**
          * Add a custom style to get looked up. If you use a custom class that has a parent style
          * which is not part of the default android styles you will need to add it here.
@@ -290,6 +297,15 @@ public class CalligraphyConfig {
         public Builder addCustomStyle(final Class<? extends TextView> styleClass, final int styleResourceAttribute) {
             if (styleClass == null || styleResourceAttribute == 0) return this;
             mStyleClassMap.put(styleClass, styleResourceAttribute);
+            return this;
+        }
+
+        /**
+         * Registering custom view with setTypeface method to apply typeface during inflation via reflection
+         */
+        public Builder addCustomViewWithSetTypeface(Class<?> clazz) {
+            customViewTypefaceSupport = true;
+            mHasTypefaceClasses.add(clazz);
             return this;
         }
 

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
@@ -101,6 +101,10 @@ public class CalligraphyConfig {
      */
     private final boolean mCustomViewCreation;
     /**
+     * Use Reflection to try to set typeface for custom views if they has setTypeface method
+     */
+    private final boolean mCustomViewTypefaceSupport;
+    /**
      * Class Styles. Build from DEFAULT_STYLES and the builder.
      */
     private final Map<Class<? extends TextView>, Integer> mClassStyleAttributeMap;
@@ -111,6 +115,7 @@ public class CalligraphyConfig {
         mAttrId = builder.attrId;
         mReflection = builder.reflection;
         mCustomViewCreation = builder.customViewCreation;
+        mCustomViewTypefaceSupport = builder.customViewTypefaceSupport;
         final Map<Class<? extends TextView>, Integer> tempMap = new HashMap<>(DEFAULT_STYLES);
         tempMap.putAll(builder.mStyleClassMap);
         mClassStyleAttributeMap = Collections.unmodifiableMap(tempMap);
@@ -138,6 +143,10 @@ public class CalligraphyConfig {
         return mCustomViewCreation;
     }
 
+    public boolean isCustomViewTypefaceSupport() {
+        return mCustomViewTypefaceSupport;
+    }
+
     /* default */ Map<Class<? extends TextView>, Integer> getClassStyles() {
         return mClassStyleAttributeMap;
     }
@@ -162,6 +171,10 @@ public class CalligraphyConfig {
          * Use Reflection to intercept CustomView inflation with the correct Context.
          */
         private boolean customViewCreation = true;
+        /**
+         * Use Reflection during view creation to try change typeface via setTypeface method if it exists
+         */
+        private boolean customViewTypefaceSupport = false;
         /**
          * The fontAttrId to look up the font path from.
          */
@@ -250,6 +263,11 @@ public class CalligraphyConfig {
          */
         public Builder disableCustomViewInflation() {
             this.customViewCreation = false;
+            return this;
+        }
+
+        public Builder setCustomViewTypefaceSupport(boolean support) {
+            this.customViewTypefaceSupport = support;
             return this;
         }
 

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/HasTypeface.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/HasTypeface.java
@@ -1,0 +1,22 @@
+package uk.co.chrisjenx.calligraphy;
+
+import android.graphics.Typeface;
+
+/**
+ * There are two ways to set typeface for custom views:
+ * <ul>
+ *     <li>Implementing this interface. You should only implements {@link #setTypeface(Typeface)} method.</li>
+ *     <li>Or via reflection. If custom view already has setTypeface method you can
+ *     register it during Calligraphy configuration
+ *     {@link uk.co.chrisjenx.calligraphy.CalligraphyConfig.Builder#addCustomViewWithSetTypeface(Class)}</li>
+ * </ul>
+ * First way is faster but encourage more effort from the developer to implements interface. Second one
+ * requires less effort but works slowly cause reflection calls.
+ *
+ * @author Dmitriy Tarasov
+ */
+public interface HasTypeface {
+
+    void setTypeface(Typeface typeface);
+
+}

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/ReflectionUtils.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/ReflectionUtils.java
@@ -1,5 +1,7 @@
 package uk.co.chrisjenx.calligraphy;
 
+import android.util.Log;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -9,6 +11,8 @@ import java.lang.reflect.Method;
  * For Calligraphy.
  */
 class ReflectionUtils {
+
+    private static final String TAG = ReflectionUtils.class.getSimpleName();
 
     static Field getField(Class clazz, String fieldName) {
         try {
@@ -50,8 +54,8 @@ class ReflectionUtils {
         try {
             if (method == null) return;
             method.invoke(object, args);
-        } catch (IllegalAccessException | InvocationTargetException ignored) {
-            ignored.printStackTrace();
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            Log.d(TAG, "Can't invoke method using reflection", e);
         }
     }
 }


### PR DESCRIPTION
Not all views that can render text are descendants of TextView. Therefore, for instance custom views based on View instead of TextView or any other views will be ignored by Calligraphy.

This pull request adds ability to change typeface for such views. This views should have setTypeface method which will be called after inflating via reflection.

The feature is optional and disabled by default. To enable it, you should change related property via config builder