### PR TITLE
Opened up to some of the helper methods in the CalligraphyUtils.java

### DIFF
--- a/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/PlaceholderFragment.java
+++ b/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/PlaceholderFragment.java
@@ -8,10 +8,13 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewStub;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
+import uk.co.chrisjenx.calligraphy.CalligraphyUtils;
 
 /**
  * A placeholder fragment containing a simple view.
@@ -37,6 +40,14 @@ public class PlaceholderFragment extends Fragment {
 
         ViewStub stubWithFontPath = ButterKnife.findById(view, R.id.stub_with_font_path);
         stubWithFontPath.inflate();
+
+        final TextView textViewInCode = new TextView(getActivity(), null, R.attr.customTextStyle);
+        textViewInCode.setText("Text view instantiated from code");
+        final String resolvedFontPath = CalligraphyUtils.resolveFontPath(getActivity(), null, R.attr.customTextStyle, CalligraphyConfig.get());
+        CalligraphyUtils.applyFontToTextView(getActivity(), textViewInCode, CalligraphyConfig.get(), resolvedFontPath);
+
+        final ViewGroup container = (ViewGroup) view.findViewById(R.id.fragment_main_samples);
+        container.addView(textViewInCode);
     }
 
     @OnClick({R.id.button_bold})

--- a/CalligraphySample/src/main/res/layout/fragment_main.xml
+++ b/CalligraphySample/src/main/res/layout/fragment_main.xml
@@ -6,6 +6,7 @@
     android:fillViewport="true">
 
     <LinearLayout
+        android:id="@+id/fragment_main_samples"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"

--- a/CalligraphySample/src/main/res/values/attrs.xml
+++ b/CalligraphySample/src/main/res/values/attrs.xml
@@ -2,5 +2,6 @@
 <resources>
 
     <attr name="textFieldStyle" format="reference"/>
+    <attr name="customTextStyle" format="reference"/>
 
 </resources>

--- a/CalligraphySample/src/main/res/values/styles.xml
+++ b/CalligraphySample/src/main/res/values/styles.xml
@@ -11,6 +11,7 @@
         <item name="android:actionBarStyle">@style/AppTheme.ActionBar</item>
         <!-- Custom Style Attribute-->
         <item name="textFieldStyle">@style/TextField</item>
+        <item name="customTextStyle">@style/CustomTextStyle</item>
     </style>
 
     <!-- AppTheme ActionBar Style -->
@@ -59,6 +60,12 @@
     <style name="TextField" parent="android:Widget.Holo.Light.TextView">
         <item name="fontPath">fonts/gtw.ttf</item>
         <item name="android:textSize">@dimen/abc_text_size_small_material</item>
+    </style>
+
+    <style name="CustomTextStyle" parent="android:Widget.Holo.Light.TextView">
+        <item name="fontPath">fonts/Oswald-Stencbab.ttf</item>
+        <item name="android:textSize">@dimen/abc_text_size_small_material</item>
+        <item name="android:lineSpacingExtra">4dp</item>
     </style>
 
 </resources>

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
@@ -144,6 +144,50 @@ public final class CalligraphyUtils {
         applyFontToTextView(context, textView, config, deferred);
     }
 
+    public static String resolveFontPath(Context context, AttributeSet attrs, int styleAttrId, CalligraphyConfig config) {
+        return resolveFontPath(context, attrs, styleAttrId, config.getAttrId());
+    }
+
+    public static String resolveFontPath(Context context, AttributeSet attrs, int styleAttrId, int attributeId) {
+        return resolveFontPath(context, attrs, styleAttrId, -1, attributeId);
+    }
+
+    public static String resolveFontPath(Context context, AttributeSet attrs, final int styleAttrId, final int subStyleAttrId, int attributeId) {
+        return resolveFontPath(context, attrs, attributeId, null, new StyleProvider() {
+            @Override
+            public int[] onProvideStyleForTextView(TextView textView) {
+                return new int[] {styleAttrId, subStyleAttrId};
+            }
+        });
+    }
+
+    static String resolveFontPath(Context context, AttributeSet attrs, int attributeId, TextView textView, StyleProvider styleProvider) {
+        // Try view xml attributes
+        String textViewFont = CalligraphyUtils.pullFontPathFromView(context, attrs, attributeId);
+
+        // Try view style attributes
+        if (TextUtils.isEmpty(textViewFont)) {
+            textViewFont = CalligraphyUtils.pullFontPathFromStyle(context, attrs, attributeId);
+        }
+
+        // Try View TextAppearance
+        if (TextUtils.isEmpty(textViewFont)) {
+            textViewFont = CalligraphyUtils.pullFontPathFromTextAppearance(context, attrs, attributeId);
+        }
+
+        // Try theme attributes
+        if (TextUtils.isEmpty(textViewFont)) {
+            final int[] styleForTextView = styleProvider.onProvideStyleForTextView(textView);
+            if (styleForTextView[1] != -1) {
+                textViewFont = CalligraphyUtils.pullFontPathFromTheme(context, styleForTextView[0], styleForTextView[1], attributeId);
+            } else {
+                textViewFont = CalligraphyUtils.pullFontPathFromTheme(context, styleForTextView[0], attributeId);
+            }
+        }
+
+        return textViewFont;
+    }
+
     /**
      * Tries to pull the Custom Attribute directly from the TextView.
      *

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
@@ -34,7 +34,7 @@ public final class CalligraphyUtils {
             if (!(s instanceof Spannable)) {
                 s = new SpannableString(s);
             }
-            ((Spannable) s).setSpan(TypefaceUtils.getSpan(typeface), 0, s.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            ((Spannable) s).setSpan(new CalligraphyTypefaceSpan(typeface), 0, s.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
         return s;
     }

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/StyleProvider.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/StyleProvider.java
@@ -1,0 +1,7 @@
+package uk.co.chrisjenx.calligraphy;
+
+import android.widget.TextView;
+
+interface StyleProvider {
+    int[] onProvideStyleForTextView(TextView textView);
+}

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/TypefaceUtils.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/TypefaceUtils.java
@@ -19,7 +19,6 @@ import java.util.Map;
 public final class TypefaceUtils {
 
     private static final Map<String, Typeface> sCachedFonts = new HashMap<String, Typeface>();
-    private static final Map<Typeface, CalligraphyTypefaceSpan> sCachedSpans = new HashMap<Typeface, CalligraphyTypefaceSpan>();
 
     /**
      * A helper loading a custom font.
@@ -42,24 +41,6 @@ public final class TypefaceUtils {
                 return null;
             }
             return sCachedFonts.get(filePath);
-        }
-    }
-
-    /**
-     * A helper loading custom spans so we don't have to keep creating hundreds of spans.
-     *
-     * @param typeface not null typeface
-     * @return will return null of typeface passed in is null.
-     */
-    public static CalligraphyTypefaceSpan getSpan(final Typeface typeface) {
-        if (typeface == null) return null;
-        synchronized (sCachedSpans) {
-            if (!sCachedSpans.containsKey(typeface)) {
-                final CalligraphyTypefaceSpan span = new CalligraphyTypefaceSpan(typeface);
-                sCachedSpans.put(typeface, span);
-                return span;
-            }
-            return sCachedSpans.get(typeface);
         }
     }
 


### PR DESCRIPTION
The reason for is being that in our project we sometimes instantiate
TextViews from code and before this change, we were not able to apply
typeface provided in our custom styles.

For instance we want to be able to create a TextView with styles defined
in our theme such as
``new TextView(context, attr, R.attr.customStyleMedium)``