### PR TITLE
Each CalligraphyContext can have its own CalligraphyConfig

### DIFF
--- a/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/PlaceholderFragment.java
+++ b/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/PlaceholderFragment.java
@@ -1,6 +1,7 @@
 package uk.co.chrisjenx.calligraphy.sample;
 
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -12,6 +13,8 @@ import android.widget.Toast;
 
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
+import uk.co.chrisjenx.calligraphy.CalligraphyContextWrapper;
 
 /**
  * A placeholder fragment containing a simple view.
@@ -56,5 +59,20 @@ public class PlaceholderFragment extends Fragment {
             }
         });
         builder.create().show();
+    }
+
+    @OnClick(R.id.button_non_default_config)
+    public void onClickNonDefaultConfig() {
+        final Context calligraphyContext =
+            CalligraphyContextWrapper.wrap(getActivity(), new CalligraphyConfig.Builder()
+                    .setDefaultFontPath("fonts/Oswald-Stencbab.ttf")
+                    .setFontAttrId(R.attr.fontPath)
+                    .addCustomViewWithSetTypeface(CustomViewWithTypefaceSupport.class)
+                    .addCustomStyle(TextField.class, R.attr.textFieldStyle)
+                    .build());
+        new android.support.v7.app.AlertDialog.Builder(calligraphyContext)
+                .setTitle(R.string.dialog_non_default_config_title)
+                .setView(R.layout.dialog_non_default_config)
+                .show();
     }
 }

--- a/CalligraphySample/src/main/res/layout/dialog_non_default_config.xml
+++ b/CalligraphySample/src/main/res/layout/dialog_non_default_config.xml
@@ -19,6 +19,12 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:textSize="18sp"
+            android:text="@string/dialog_non_default_config_message"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:text="@string/default_theme"/>
 
         <TextView
@@ -77,18 +83,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
-        <ViewStub
-            android:id="@+id/stub"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout="@layout/stub"/>
-
-        <ViewStub
-            android:id="@+id/stub_with_font_path"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout="@layout/stub_with_font_path"/>
-
         <CheckBox
             fontPath="fonts/Oswald-Stencbab.ttf"
             android:layout_width="match_parent"
@@ -110,32 +104,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/custom_view_style_text"/>
-
-        <Button
-            android:id="@+id/button_default"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="16dp"
-            android:text="@string/button_default"/>
-
-        <Button
-            android:id="@+id/button_bold"
-            fontPath="fonts/Roboto-Bold.ttf"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="12dp"
-            android:text="@string/button_defined"/>
-
-        <Button
-            android:id="@+id/button_non_default_config"
-            fontPath="fonts/Roboto-Bold.ttf"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="12dp"
-            android:text="@string/button_non_default_config"/>
 
     </LinearLayout>
 </ScrollView>

--- a/CalligraphySample/src/main/res/values/strings.xml
+++ b/CalligraphySample/src/main/res/values/strings.xml
@@ -22,5 +22,8 @@
 
     <string name="button_default">Default Font (show dialog)</string>
     <string name="button_defined">Bold Button (show toast)</string>
+    <string name="button_non_default_config">Context specific Calligraphy config (show dialog)</string>
+    <string name="dialog_non_default_config_title">Context specific Calligraphy config</string>
+    <string name="dialog_non_default_config_message">\nUsing non-global Calligraphy config for this dialog with Oswald as the default font.\n</string>
 
 </resources>

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
@@ -1,5 +1,6 @@
 package uk.co.chrisjenx.calligraphy;
 
+import android.content.Context;
 import android.os.Build;
 import android.text.TextUtils;
 import android.view.View;
@@ -74,13 +75,26 @@ public class CalligraphyConfig {
     }
 
     /**
-     * The current Calligraphy Config.
+     * The default Calligraphy config.
      * If not set it will create a default config.
      */
     public static CalligraphyConfig get() {
         if (sInstance == null)
             sInstance = new CalligraphyConfig(new Builder());
         return sInstance;
+    }
+
+    /**
+     * Obtains the CalligraphyConfig from the given context.
+     */
+    static CalligraphyConfig from(Context context) {
+        //noinspection ResourceType
+        final CalligraphyConfig config = (CalligraphyConfig) context
+            .getSystemService(CalligraphyContextWrapper.CALLIGRAPHY_CONFIG_SERVICE);
+        if (config == null) {
+            throw new AssertionError("CalligraphyConfig not found.");
+        }
+        return config;
     }
 
     /**

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyContextWrapper.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyContextWrapper.java
@@ -13,22 +13,38 @@ import android.view.View;
  */
 public class CalligraphyContextWrapper extends ContextWrapper {
 
+    static final String CALLIGRAPHY_CONFIG_SERVICE = CalligraphyConfig.class.getName();
+
     private CalligraphyLayoutInflater mInflater;
 
     private final int mAttributeId;
+    private final CalligraphyConfig mCalligraphyConfig;
 
     /**
-     * Uses the default configuration from {@link uk.co.chrisjenx.calligraphy.CalligraphyConfig}
+     * Convenience for calling {@link #wrap(Context, CalligraphyConfig)} with the
+     * {@linkplain CalligraphyConfig#get default configuration}.
      *
      * Remember if you are defining default in the
      * {@link uk.co.chrisjenx.calligraphy.CalligraphyConfig} make sure this is initialised before
      * the activity is created.
-     *
-     * @param base ContextBase to Wrap.
-     * @return ContextWrapper to pass back to the activity.
      */
     public static ContextWrapper wrap(Context base) {
-        return new CalligraphyContextWrapper(base);
+        return wrap(base, CalligraphyConfig.get());
+    }
+
+    /**
+     * Configures Calligraphy to be used in the {@code context} with the provided {@code config}.
+     *
+     * <p>You would rarely need to use this method directly, so unless you need a different
+     * configuration in multiple contexts in you app, prefer defining a
+     * {@linkplain CalligraphyConfig#initDefault default configuration} and use
+     * {@link #wrap(Context)} instead.
+     *
+     * @return Context to use as the {@linkplain Activity#attachBaseContext base context} of your
+     * Activity or for initializing a view hierarchy.
+     */
+    public static ContextWrapper wrap(Context base, CalligraphyConfig config) {
+        return new CalligraphyContextWrapper(base, config);
     }
 
     /**
@@ -72,18 +88,10 @@ public class CalligraphyContextWrapper extends ContextWrapper {
         return (CalligraphyActivityFactory) activity.getLayoutInflater();
     }
 
-    /**
-     * Uses the default configuration from {@link uk.co.chrisjenx.calligraphy.CalligraphyConfig}
-     *
-     * Remember if you are defining default in the
-     * {@link uk.co.chrisjenx.calligraphy.CalligraphyConfig} make sure this is initialised before
-     * the activity is created.
-     *
-     * @param base ContextBase to Wrap
-     */
-    CalligraphyContextWrapper(Context base) {
+    CalligraphyContextWrapper(Context base, CalligraphyConfig config) {
         super(base);
-        mAttributeId = CalligraphyConfig.get().getAttrId();
+        mAttributeId = config.getAttrId();
+        mCalligraphyConfig = config;
     }
 
     /**
@@ -102,6 +110,7 @@ public class CalligraphyContextWrapper extends ContextWrapper {
     public CalligraphyContextWrapper(Context base, int attributeId) {
         super(base);
         mAttributeId = attributeId;
+        mCalligraphyConfig = null;
     }
 
     @Override
@@ -111,6 +120,9 @@ public class CalligraphyContextWrapper extends ContextWrapper {
                 mInflater = new CalligraphyLayoutInflater(LayoutInflater.from(getBaseContext()), this, mAttributeId, false);
             }
             return mInflater;
+        }
+        if (CALLIGRAPHY_CONFIG_SERVICE.equals(name)) {
+            return mCalligraphyConfig != null ? mCalligraphyConfig : CalligraphyConfig.get();
         }
         return super.getSystemService(name);
     }

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
@@ -36,9 +36,10 @@ class CalligraphyFactory {
             styleIds[1] = android.R.attr.subtitleTextStyle;
         }
         if (styleIds[0] == -1) {
+            final CalligraphyConfig config = CalligraphyConfig.from(view.getContext());
             // Use TextAppearance as default style
-            styleIds[0] = CalligraphyConfig.get().getClassStyles().containsKey(view.getClass())
-                    ? CalligraphyConfig.get().getClassStyles().get(view.getClass())
+            styleIds[0] = config.getClassStyles().containsKey(view.getClass())
+                    ? config.getClassStyles().get(view.getClass())
                     : android.R.attr.textAppearance;
         }
         return styleIds;
@@ -117,6 +118,7 @@ class CalligraphyFactory {
     }
 
     void onViewCreatedInternal(View view, final Context context, AttributeSet attrs) {
+        final CalligraphyConfig config = CalligraphyConfig.from(context);
         if (view instanceof TextView) {
             // Fast path the setting of TextView's font, means if we do some delayed setting of font,
             // which has already been set by use we skip this TextView (mainly for inflating custom,
@@ -142,7 +144,7 @@ class CalligraphyFactory {
             // Still need to defer the Native action bar, appcompat-v7:21+ uses the Toolbar underneath. But won't match these anyway.
             final boolean deferred = matchesResourceIdName(view, ACTION_BAR_TITLE) || matchesResourceIdName(view, ACTION_BAR_SUBTITLE);
 
-            CalligraphyUtils.applyFontToTextView(context, (TextView) view, CalligraphyConfig.get(), textViewFont, deferred);
+            CalligraphyUtils.applyFontToTextView(context, (TextView) view, config, textViewFont, deferred);
         }
 
         // AppCompat API21+ The ActionBar doesn't inflate default Title/SubTitle, we need to scan the
@@ -178,7 +180,7 @@ class CalligraphyFactory {
             if (typeface != null) {
                 ((HasTypeface) view).setTypeface(typeface);
             }
-        } else if (CalligraphyConfig.get().isCustomViewTypefaceSupport() && CalligraphyConfig.get().isCustomViewHasTypeface(view)) {
+        } else if (config.isCustomViewTypefaceSupport() && config.isCustomViewHasTypeface(view)) {
             final Method setTypeface = ReflectionUtils.getMethod(view.getClass(), "setTypeface");
             String fontPath = resolveFontPath(context, attrs);
             Typeface typeface = getDefaultTypeface(context, fontPath);
@@ -190,7 +192,7 @@ class CalligraphyFactory {
 
     private Typeface getDefaultTypeface(Context context, String fontPath) {
         if (TextUtils.isEmpty(fontPath)) {
-            fontPath = CalligraphyConfig.get().getFontPath();
+            fontPath = CalligraphyConfig.from(context).getFontPath();
         }
         if (!TextUtils.isEmpty(fontPath)) {
             return TypefaceUtils.load(context.getAssets(), fontPath);

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyLayoutInflater.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyLayoutInflater.java
@@ -4,6 +4,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -26,6 +27,7 @@ class CalligraphyLayoutInflater extends LayoutInflater implements CalligraphyAct
 
     private final int mAttributeId;
     private final CalligraphyFactory mCalligraphyFactory;
+    private final CalligraphyConfig mCalligraphyConfig;
     // Reflection Hax
     private boolean mSetPrivateFactory = false;
     private Field mConstructorArgs = null;
@@ -34,12 +36,14 @@ class CalligraphyLayoutInflater extends LayoutInflater implements CalligraphyAct
         super(context);
         mAttributeId = attributeId;
         mCalligraphyFactory = new CalligraphyFactory(attributeId);
+        mCalligraphyConfig = CalligraphyConfig.from(context);
         setUpLayoutFactories(false);
     }
 
     protected CalligraphyLayoutInflater(LayoutInflater original, Context newContext, int attributeId, final boolean cloned) {
         super(original, newContext);
         mAttributeId = attributeId;
+        mCalligraphyConfig = CalligraphyConfig.from(newContext);
         mCalligraphyFactory = new CalligraphyFactory(attributeId);
         setUpLayoutFactories(cloned);
     }
@@ -105,7 +109,7 @@ class CalligraphyLayoutInflater extends LayoutInflater implements CalligraphyAct
         // Already tried to set the factory.
         if (mSetPrivateFactory) return;
         // Reflection (Or Old Device) skip.
-        if (!CalligraphyConfig.get().isReflection()) return;
+        if (!mCalligraphyConfig.isReflection()) return;
         // Skip if not attached to an activity.
         if (!(getContext() instanceof Factory2)) {
             mSetPrivateFactory = true;
@@ -195,7 +199,7 @@ class CalligraphyLayoutInflater extends LayoutInflater implements CalligraphyAct
         // significant difference to performance on Android 4.0+.
 
         // If CustomViewCreation is off skip this.
-        if (!CalligraphyConfig.get().isCustomViewCreation()) return view;
+        if (!mCalligraphyConfig.isCustomViewCreation()) return view;
         if (view == null && name.indexOf('.') > -1) {
             if (mConstructorArgs == null)
                 mConstructorArgs = ReflectionUtils.getField(LayoutInflater.class, "mConstructorArgs");


### PR DESCRIPTION
Useful when Calligraphy is used in a library project where the default
configuration need not be changed, or when different defaults are needed
in multiple contexts.
