### PR TITLE
copy lineSpacingExtra and lineSpacingMultiplier from textAppearance

### DIFF
--- a/CalligraphySample/src/main/res/layout/fragment_main.xml
+++ b/CalligraphySample/src/main/res/layout/fragment_main.xml
@@ -66,6 +66,12 @@
             android:textAllCaps="true"
             android:textAppearance="@style/TextAppearance.FontPathView"/>
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/defined_in_appears_linespacing"
+            android:textAppearance="@style/TextAppearance.FontPathView.WithSpacing"/>
+
         <uk.co.chrisjenx.calligraphy.sample.CustomTextView
             fontPath="fonts/Oswald-Stencbab.ttf"
             android:layout_width="wrap_content"

--- a/CalligraphySample/src/main/res/values/strings.xml
+++ b/CalligraphySample/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="defined_in_appears_style">\nThis has the font path defined in the Styles TextAppearance as Roboto Condensed.\n</string>
     <string name="defined_in_appears">\nThis has the font path defined in the Views TextAppearance as Oswald.\n</string>
     <string name="defined_in_appears_caps">\nThis has the font path defined in the Views TextAppearance as Oswald. textAllCaps is applied.\n</string>
+    <string name="defined_in_appears_linespacing">\nThis has the font path defined in the Views TextAppearance as Oswald. lineSpacingExtra is applied.\n</string>
     <string name="defined_custom_view">\nThis is a custom TextView with Oswald font.\n</string>
     <string name="defined_view_stub">\nThis is a TextView inflated from a ViewStub.\n</string>
     <string name="defined_view_stub_font_path">\nThis is a TextView inflated from a ViewStub w/ fontPath declared.\n</string>

--- a/CalligraphySample/src/main/res/values/styles.xml
+++ b/CalligraphySample/src/main/res/values/styles.xml
@@ -60,6 +60,10 @@
         <item name="android:textColor">#444</item>
     </style>
 
+    <style name="TextAppearance.FontPathView.WithSpacing" parent="TextAppearance.FontPathView">
+        <item name="android:lineSpacingExtra">20dp</item>
+    </style>
+
     <!-- Custom Class Styles -->
     <style name="TextField" parent="android:Widget.Holo.Light.TextView">
         <item name="fontPath">fonts/gtw.ttf</item>

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
@@ -144,6 +144,7 @@ class CalligraphyFactory {
             final boolean deferred = matchesResourceIdName(view, ACTION_BAR_TITLE) || matchesResourceIdName(view, ACTION_BAR_SUBTITLE);
 
             CalligraphyUtils.applyFontToTextView(context, (TextView) view, CalligraphyConfig.get(), textViewFont, deferred);
+            CalligraphyUtils.applyExtraAttributesToTextView(context, (TextView) view, attrs);
         }
 
         // AppCompat API21+ The ActionBar doesn't inflate default Title/SubTitle, we need to scan the

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
@@ -24,6 +24,11 @@ public final class CalligraphyUtils {
 
     public static final int[] ANDROID_ATTR_TEXT_APPEARANCE = new int[]{android.R.attr.textAppearance};
 
+    static final int[] EXTRA_TEXT_APPEARANCE = {
+        android.R.attr.lineSpacingExtra,
+        android.R.attr.lineSpacingMultiplier
+    };
+
     /**
      * Applies a custom typeface span to the text.
      *
@@ -310,6 +315,39 @@ public final class CalligraphyUtils {
             }
         }
         return null;
+    }
+
+    static void applyExtraAttributesToTextView(final Context context, final TextView view, final AttributeSet attrs) {
+        int textAppearanceId = -1;
+        final TypedArray typedArrayAttr = context.obtainStyledAttributes(attrs, ANDROID_ATTR_TEXT_APPEARANCE);
+        if (typedArrayAttr != null) {
+            try {
+                textAppearanceId = typedArrayAttr.getResourceId(0, -1);
+            } catch (Exception ignored) {
+                // Failed for some reason
+                return;
+            } finally {
+                typedArrayAttr.recycle();
+            }
+        }
+
+        final TypedArray appearance = context.obtainStyledAttributes(textAppearanceId, EXTRA_TEXT_APPEARANCE);
+        if (appearance != null) {
+            int lineSpacingExtra = 0;
+            float lineSpacingMultiplier = 1;
+            for (int n = 0; n < appearance.getIndexCount(); n++) {
+                switch (EXTRA_TEXT_APPEARANCE[n]) {
+                    case android.R.attr.lineSpacingExtra:
+                        lineSpacingExtra = appearance.getDimensionPixelSize(n, lineSpacingExtra);
+                        break;
+                    case android.R.attr.lineSpacingMultiplier:
+                        lineSpacingMultiplier = appearance.getFloat(n, lineSpacingMultiplier);
+                        break;
+                }
+            }
+            appearance.recycle();
+            view.setLineSpacing(lineSpacingExtra, lineSpacingMultiplier);
+        }
     }
 
     private static Boolean sToolbarCheck = null;

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyUtils.java
@@ -346,7 +346,9 @@ public final class CalligraphyUtils {
                 }
             }
             appearance.recycle();
-            view.setLineSpacing(lineSpacingExtra, lineSpacingMultiplier);
+            if (view.getLineSpacingExtra() == 0 && view.getLineSpacingMultiplier() == 1) {
+                view.setLineSpacing(lineSpacingExtra, lineSpacingMultiplier);
+            }
         }
     }
 


### PR DESCRIPTION
Maybe you like this as a concept, maybe you consider it out of scope. But my designers really care about line spacing, and I wanted to set it globally and not have to put lineSpacingExtra on every TextView in my app. So the obvious thing to do is put `lineSpacingExtra` in the `textAppearance`. Nope. Won't work.

Given that CalligraphyFactory is doing things to the text view _anyway_, this patch will make it copy lineSpacingExtra and lineSpacingMultiplier from textAppearance if present, so I can set those in my styles and make my designers happy.
