### PR TITLE
Fix snapshot version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #Changelog
 
-#2.2.0 (16/07/2015)-SNAPSHOT
+#2.1.1 (29/02/2016)-SNAPSHOT
 - Added AppCompat Styles (AppCompatTextView will now pickup textViewStyle etc). Thanks @paul-turner
 - Fix for Toolbar not inflating `TextView`s upfront.
 


### PR DESCRIPTION
According to https://oss.sonatype.org/content/repositories/snapshots/uk/co/chrisjenx/calligraphy/ the snapshot version is 2.1.1 and was published on February the 29th this year.