### PR TITLE
Remove redundant check

### DIFF
--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
@@ -214,7 +214,7 @@ public class CalligraphyConfig {
          * @return this builder.
          */
         public Builder setFontAttrId(int fontAssetAttrId) {
-            this.attrId = fontAssetAttrId != INVALID_ATTR_ID ? fontAssetAttrId : INVALID_ATTR_ID;
+            this.attrId = fontAssetAttrId;
             return this;
         }
 


### PR DESCRIPTION
Remove a redundant check. If `fontAssetAttrId` is `INVALID_ATTR_ID`, `attrId` we'll be too, and not otherwise.