### PR TITLE
Fixed incorrect style attribute reference of compat widget

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.0-beta1'
+    classpath 'com.android.tools.build:gradle:2.1.0'
   }
 }
 

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
@@ -52,13 +52,13 @@ public class CalligraphyConfig {
      */
     private static void addAppCompatViews() {
         DEFAULT_STYLES.put(android.support.v7.widget.AppCompatTextView.class, android.R.attr.textViewStyle);
-        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatButton.class, android.R.attr.buttonStyle);
-        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatEditText.class, android.R.attr.editTextStyle);
-        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatAutoCompleteTextView.class, android.R.attr.autoCompleteTextViewStyle);
-        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatMultiAutoCompleteTextView.class, android.R.attr.autoCompleteTextViewStyle);
-        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatCheckBox.class, android.R.attr.checkboxStyle);
-        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatRadioButton.class, android.R.attr.radioButtonStyle);
-        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatCheckedTextView.class, android.R.attr.checkedTextViewStyle);
+        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatButton.class, android.support.v7.appcompat.R.attr.buttonStyle);
+        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatEditText.class, android.support.v7.appcompat.R.attr.editTextStyle);
+        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatAutoCompleteTextView.class, android.support.v7.appcompat.R.attr.autoCompleteTextViewStyle);
+        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatMultiAutoCompleteTextView.class, android.support.v7.appcompat.R.attr.autoCompleteTextViewStyle);
+        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatCheckBox.class, android.support.v7.appcompat.R.attr.checkboxStyle);
+        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatRadioButton.class, android.support.v7.appcompat.R.attr.radioButtonStyle);
+        DEFAULT_STYLES.put(android.support.v7.widget.AppCompatCheckedTextView.class, android.support.v7.appcompat.R.attr.checkedTextViewStyle);
     }
 
     private static CalligraphyConfig sInstance;


### PR DESCRIPTION
In the existing implementation of CalligraphyConfig compat library style attributes are incorrectly referring to style attributes of the framework. Typeface defined in the style of a for instance an AppCompatButton is not set. In code:

### This did not work before this fix
```
    <style name="Widget.MyCompany.Button" parent="Widget.AppCompat.Button.Colored">
        <item name="typefacePath">@string/my_company_font</item>
        <item name="android:textAllCaps">false</item>
        <item name="android:textSize">16sp</item>
        <item name="android:minHeight">52dp</item>
    </style>

    <style name="Theme.MyCompany" parent="Theme.AppCompat.Light">
        ...
        <item name="buttonStyle">@style/Widget.MyCompany.Button</item>
        ...
    </style>

    <Button
        android:id="@+id/my_lovely_button"
        android:layout_width="match_parent"
        android:layout_height="wrap_content"
        android:text="Start something something" />
```