### PR TITLE
Restore stored subtitle only if it wasn't modified by user

### DIFF
--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
@@ -237,7 +237,9 @@ class CalligraphyFactory {
                 }
             }
             removeSelf(toolbar);
-            toolbar.setSubtitle(originalSubTitle);
+            if (TextUtils.equals(toolbar.getSubtitle(), BLANK)) {
+                toolbar.setSubtitle(originalSubTitle);
+            }
         }
 
         private void removeSelf(final Toolbar toolbar) {// Our dark deed is done


### PR DESCRIPTION
This is an attempt to fix #280.
# Issue

When users modify subtitle early before OnGlobalLayoutListener gets called (e.g. in onCreate) it is lost and overriden by previously stored value.
# My solution

This change restores the subtitle only if it is still set to `BLANK` which most likely means that the user didn't modify it manually. This way the only situation when subtitle set by user would be lost is if they set it to `BLANK`. I think we can safely ignore this edge case.
# Testing

I tested this inside of the provided sample by replacing [Handler calls](https://github.com/chrisjenx/Calligraphy/blob/master/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/MainActivity.java#L30) with `toolbar.setSubtitle("Text")`. Without this pull request applied subtitle wouldn't be visible, but with it `Text` correctly appeared.

I also tested it with existing handlers to confirm that custom font is still set and I didn't see anything wrong.
