### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,22 @@
-#Changelog
+# Changelog
 
-#2.2.0 (05/04/2016)
+# 2.2.0 (05/04/2016)
 - Added AppCompat Styles (AppCompatTextView will now pickup textViewStyle etc). Thanks @paul-turner
 - Fix for Toolbar not inflating `TextView`s upfront.
 
-#2.1.0 (27/04/2015)
+# 2.1.0 (27/04/2015)
 - Fixed #155, We now clone correctly.
 - Added Styles for Custom Views. (`builder.addCustomStyle(ToggleButton.class, android.R.attr.buttonStyleToggle)`)
 
-#2.0.2 (05/01/2015)
+# 2.0.2 (05/01/2015)
 - Fixed `CalligraphyConfig.Builder` missing return statements.
 - Fixed `createView()` getting the wrong parent context, Fixed: #135, #120
 
-#2.0.1 (28/01/2014)
+# 2.0.1 (28/01/2014)
 - Throw exception on passing null into `CalligraphySpan`
 - Fixed memory bug with `Toolbar`. [@dlew](https://github.com/dlew)
 
-#2.0.0 (16/01/2014)
+# 2.0.0 (16/01/2014)
 **Breaking changes**
 This is a massive rewrite of the interception model. Look at `CalligraphyLayoutInflater` and
 `CalligraphyConfig` for more information on options and changes.
@@ -32,42 +32,42 @@ Notable changes:
 - We wrap Factory not disturbing underlying factory and layout inflater invocation.
 - Better support for `cloneInContext()` which the compat library uses heavily.
 
-#1.2.0 (20/10/2014)
+# 1.2.0 (20/10/2014)
 - Fixes issues with `appcompat-v7:21+` (uses underlying `Toolbar` impl).
 - Lollipop support.
 - Fast path view with font already set by us.
 
-#1.1.0 (02/08/2014)
+# 1.1.0 (02/08/2014)
 - Fixes ActionBar Title/SubTitle `textStyles`.
 - Fixes `textAllCaps` bug, now works correctly.
 - Fixes some `Spannable` issues reported, we are more careful what we apply `Spannable`'s too now.
 - Fixes missing Typeface on hint text on `EditText`/`AutoComplete`.
 - Fixes empty source and javadoc jars on maven.
 
-#1.0.0 (05/07/2014)
+# 1.0.0 (05/07/2014)
 - Added ActionBar Title/SubTitle support.
 - Toast support via default style/or TextView theme style.
 - Removed FontFamily parsing as it lead to users not being able to use `fontFamily`
 - Added TextAppearance Support - Thanks [@codebutler](https://github.com/codebutler) & [@loganj](https://github.com/loganj)
 - Default Font no longer required.
 
-#0.8/9 (Skipped major API change)
+# 0.8/9 (Skipped major API change)
 
-#0.7.1 (22/04/2014)
+# 0.7.1 (22/04/2014)
 - Fixed Resources not found Exception - [@Smuldr](https://github.com/Smuldr)
 
-#0.7.0 (28/01/2014)
+# 0.7.0 (28/01/2014)
 - Added Anti-aliasing support
 - Added custom font attribute support - Thanks [@Roman Zhilich](https://github.com/RomanZhilich)
 - Changed Maven groupId to `uk.co.chrisjenx` artifact is now `calligraphy`. `compile 'uk.co.chrisjenx:calligraphy:0.+'`
 
-#0.6.0 (02/01/2014)
+# 0.6.0 (02/01/2014)
 - Supports all Android implementations of `TextView`
 - Supports Custom `TextView`s - Thanks [@mironov-nsk](https://github.com/mironov-nsk)
 - Caches none found fonts as null
 
-#0.5.0
+# 0.5.0
 - Added support for `Button` class
 
-#0.4.0
+# 0.4.0
 - Initial Release

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Are you fed up of Custom Views to set fonts? Or traversing the ViewTree to find 
 
 ![alt text](https://github.com/chrisjenx/Calligraphy/raw/master/screenshot.png "ScreenShot Of Font Samples")
 
-##Getting started
+## Getting started
 
 ### Dependency
 
@@ -128,7 +128,7 @@ http://schemas.android.com/tools"`. See https://code.google.com/p/android/issues
 ```
 
 
-#FAQ
+# FAQ
 
 ### Font Resolution 
 
@@ -184,7 +184,7 @@ Both have a method called `setSwitchTypeface` that sets the typeface within the 
 
 
 
-#Collaborators
+# Collaborators
 
 - [@mironov-nsk](https://github.com/mironov-nsk)
 - [@Roman Zhilich](https://github.com/RomanZhilich)
@@ -193,13 +193,13 @@ Both have a method called `setSwitchTypeface` that sets the typeface within the 
 - [@loganj](https://github.com/loganj)
 - [@dlew](https://github.com/dlew)
 
-#Note
+# Note
 
 This library was created because it is currently not possible to declare a custom font in XML files in Android.
 
 If you feel this should be possible to do, please star [this issue](https://code.google.com/p/android/issues/detail?id=88945) on the official Android bug tracker.
 
-#Licence
+# Licence
 
     Copyright 2013 Christopher Jenkins
     


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
