### PR TITLE
Adds A Config Option To Provide a FontPath Substitution Map

### DIFF
--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyConfig.java
@@ -1,5 +1,6 @@
 package uk.co.chrisjenx.calligraphy;
 
+import android.content.res.AssetManager;
 import android.os.Build;
 import android.text.TextUtils;
 import android.view.View;
@@ -71,6 +72,7 @@ public class CalligraphyConfig {
      */
     public static void initDefault(CalligraphyConfig calligraphyConfig) {
         sInstance = calligraphyConfig;
+        TypefaceUtils.setFontPathSubstitutionMap(sInstance.getFontPathSubstitutionMap());
     }
 
     /**
@@ -116,6 +118,11 @@ public class CalligraphyConfig {
      * @see uk.co.chrisjenx.calligraphy.CalligraphyConfig.Builder#addCustomViewWithSetTypeface(Class)
      */
     private final Set<Class<?>> hasTypefaceViews;
+    /**
+     * A map of font paths that should be used to dynamically substitute a new fontPath for the
+     * fontPath that's specified in XML / passed to {@link TypefaceUtils#load(AssetManager, String)}
+     */
+    private Map<String, String> mFontPathSubstitutionMap = null;
 
     protected CalligraphyConfig(Builder builder) {
         mIsFontSet = builder.isFontSet;
@@ -128,6 +135,7 @@ public class CalligraphyConfig {
         tempMap.putAll(builder.mStyleClassMap);
         mClassStyleAttributeMap = Collections.unmodifiableMap(tempMap);
         hasTypefaceViews = Collections.unmodifiableSet(builder.mHasTypefaceClasses);
+        mFontPathSubstitutionMap = builder.fontPathSubstitutionMap;
     }
 
     /**
@@ -171,6 +179,10 @@ public class CalligraphyConfig {
         return mAttrId;
     }
 
+    public Map<String, String> getFontPathSubstitutionMap() {
+        return mFontPathSubstitutionMap;
+    }
+
     public static class Builder {
         /**
          * Default AttrID if not set.
@@ -206,6 +218,8 @@ public class CalligraphyConfig {
         private Map<Class<? extends TextView>, Integer> mStyleClassMap = new HashMap<>();
 
         private Set<Class<?>> mHasTypefaceClasses = new HashSet<>();
+
+        private Map<String, String> fontPathSubstitutionMap = null;
 
         /**
          * This defaults to R.attr.fontPath. So only override if you want to use your own attrId.
@@ -309,6 +323,11 @@ public class CalligraphyConfig {
         public Builder addCustomViewWithSetTypeface(Class<?> clazz) {
             customViewTypefaceSupport = true;
             mHasTypefaceClasses.add(clazz);
+            return this;
+        }
+
+        public Builder setFontPathSubstitutionMap(Map<String, String> fontPathSubstitutionMap) {
+            this.fontPathSubstitutionMap = fontPathSubstitutionMap;
             return this;
         }
 

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/TypefaceUtils.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/TypefaceUtils.java
@@ -2,6 +2,7 @@ package uk.co.chrisjenx.calligraphy;
 
 import android.content.res.AssetManager;
 import android.graphics.Typeface;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import java.util.HashMap;
@@ -20,6 +21,7 @@ public final class TypefaceUtils {
 
     private static final Map<String, Typeface> sCachedFonts = new HashMap<String, Typeface>();
     private static final Map<Typeface, CalligraphyTypefaceSpan> sCachedSpans = new HashMap<Typeface, CalligraphyTypefaceSpan>();
+    private static Map<String, String> sFontPathSubstitutionMap = null;
 
     /**
      * A helper loading a custom font.
@@ -28,9 +30,15 @@ public final class TypefaceUtils {
      * @param filePath     The path of the file.
      * @return Return {@link android.graphics.Typeface} or null if the path is invalid.
      */
-    public static Typeface load(final AssetManager assetManager, final String filePath) {
+    public static Typeface load(final AssetManager assetManager, String filePath) {
         synchronized (sCachedFonts) {
             try {
+                // If a valid fontPath substitution map exists, check if the filePath should be
+                // updated in order to load a different font.
+                if (sFontPathSubstitutionMap != null
+                        && sFontPathSubstitutionMap.containsKey(filePath)) {
+                    filePath = sFontPathSubstitutionMap.get(filePath);
+                }
                 if (!sCachedFonts.containsKey(filePath)) {
                     final Typeface typeface = Typeface.createFromAsset(assetManager, filePath);
                     sCachedFonts.put(filePath, typeface);
@@ -74,5 +82,9 @@ public final class TypefaceUtils {
     }
 
     private TypefaceUtils() {
+    }
+
+    static void setFontPathSubstitutionMap(@Nullable Map<String, String> fontPathSubstitutionMap) {
+        sFontPathSubstitutionMap = fontPathSubstitutionMap;
     }
 }

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/TypefaceUtils.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/TypefaceUtils.java
@@ -35,12 +35,19 @@ public final class TypefaceUtils {
             try {
                 // If a valid fontPath substitution map exists, check if the filePath should be
                 // updated in order to load a different font.
+                boolean loadFromFile = false;
                 if (sFontPathSubstitutionMap != null
                         && sFontPathSubstitutionMap.containsKey(filePath)) {
                     filePath = sFontPathSubstitutionMap.get(filePath);
+                    loadFromFile = true;
                 }
                 if (!sCachedFonts.containsKey(filePath)) {
-                    final Typeface typeface = Typeface.createFromAsset(assetManager, filePath);
+                    final Typeface typeface;
+                    if (loadFromFile) {
+                        typeface = Typeface.createFromFile(filePath);
+                    } else {
+                        typeface = Typeface.createFromAsset(assetManager, filePath);
+                    }
                     sCachedFonts.put(filePath, typeface);
                     return typeface;
                 }


### PR DESCRIPTION
Summary:
In order to A/B test fonts, this adds an option to the
CalligraphyConfig to provide a fontPath substitution map.
This enables dynamically changing fonts at run time and requires
no changes to XML files.
The logic to substitute the fontPath is in the TypefaceUtils.
The reason the map is set on the TypeFaceUtils class instead of the
TypefaceUtils checking the CalligraphyConfig is that this way
it doesn't require constant invocations of CalligraphyConfig.get().

Test Plan:
- Verified with sample app that the new config option works as expected.