### PR TITLE
Fix using the same string for Toolbar (sub)title

### DIFF
--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyFactory.java
@@ -196,7 +196,7 @@ class CalligraphyFactory {
     }
 
     /**
-     * Will forceably set text on the views then remove ones that didn't have copy.
+     * Will forcibly set text on the views then remove ones that didn't have copy.
      *
      * @param view toolbar view.
      */
@@ -206,8 +206,8 @@ class CalligraphyFactory {
         // The toolbar inflates both the title and the subtitle views lazily but luckily they do it
         // synchronously when you set a title and a subtitle programmatically.
         // So we set a title and a subtitle to something, then get the views, then revert.
-        view.setTitle(" ");
-        view.setSubtitle(" ");
+        view.setTitle("uk.co.chrisjenx.calligraphy:toolbar_title");
+        view.setSubtitle("uk.co.chrisjenx.calligraphy:toolbar_subtitle");
 
         // Iterate through the children to run post inflation on them
         final int childCount = view.getChildCount();


### PR DESCRIPTION
Currently the same string (" ") is set on Toolbar's title and subtitle.
This means that the factory is unable to determine whether a given
TextView inside of a Toolbar is the title or the subtitle. The
consequence is that the font is not applied properly to the subtitle.

To clarify, if you specify a titleTextAppearance and a subtitleTextAppearance, your subtitle will get its font set to the titleTextAppearance's, since it checks if the title matches first. By using unique strings, it can differentiate between the two and apply the right font to the right view.